### PR TITLE
Make the polyfill wait until after the Origin Trial as kicked in

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -69,7 +69,7 @@ window.addEventListener( 'webvr-resetpose', function() {
 
 } );
 
-var source = '(' + injectedScript + ')();';
+var source = 'setTimeout(' + injectedScript + ', 0);';
 
 var script = document.createElement('script');
 script.textContent = source;


### PR DESCRIPTION
A starting point for discussion, if nothing else. Fixes #21... mostly.

The problem is that there isn't anywhere for us to insert our script that is after the Origin Trial is loaded but before *any* page script could be run. Testing shows that the script here is injected *after* scripts in the head but *before* scripts in the body.

This means that coming in after the Origin Trial gives the page chance to get a reference to the real versions of things like `VRFrameData` and `navigator.getVRDisplays()`.

For me personally, I load my scripts in the body, and this change fixes things perfectly. For people who run their scripts in the head I'm not sure what happens.